### PR TITLE
disable quickedit at startup

### DIFF
--- a/TinyNvidiaUpdateChecker/ConsoleQuickEdit.cs
+++ b/TinyNvidiaUpdateChecker/ConsoleQuickEdit.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Runtime.InteropServices;
+namespace TinyNvidiaUpdateChecker
+{
+    public static class ConsoleQuickEdit
+    {
+        const uint ENABLE_QUICK_EDIT = 0x0040;
+        const int STD_INPUT_HANDLE = -10;
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        static extern IntPtr GetStdHandle(int nStdHandle);
+
+        [DllImport("kernel32.dll")]
+        static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
+
+        [DllImport("kernel32.dll")]
+        static extern bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
+
+        internal static bool DisableQuickEdit()
+        {
+            IntPtr consoleH = GetStdHandle(STD_INPUT_HANDLE);
+            uint mode;
+            if (!GetConsoleMode(consoleH, out mode))
+            {
+                return false;
+            }
+            mode &= ~ENABLE_QUICK_EDIT;
+            if (!SetConsoleMode(consoleH, mode))
+            {
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/TinyNvidiaUpdateChecker/MainConsole.cs
+++ b/TinyNvidiaUpdateChecker/MainConsole.cs
@@ -163,6 +163,13 @@ namespace TinyNvidiaUpdateChecker
 
             bool hasSelected = false;
             int iOffline = 0;
+            try
+            {
+                ConsoleQuickEdit.DisableQuickEdit();
+            } catch (Exception ex) {
+                Console.WriteLine("Could not disable QuickEdit of Console");
+                Console.WriteLine(ex.ToString());
+            }
 
             try {
                 iOffline = Convert.ToInt32(OfflineGPUVersion.Replace(".", string.Empty));


### PR DESCRIPTION
implemented function to disable QuickEdit (selecting text) in console. Solves the problem of a freezed progressbar when clicking the window.