### PR TITLE
Added '--install-components' command line argument

### DIFF
--- a/TinyNvidiaUpdateChecker/AnonymousEqualityComparer.cs
+++ b/TinyNvidiaUpdateChecker/AnonymousEqualityComparer.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace TinyNvidiaUpdateChecker
+{
+    public class AnonymousEqualityComparer<T> : IEqualityComparer<T>
+    {
+        private readonly Func<T, T, bool> equals;
+        private readonly Func<T, int> getHashCode;
+
+        public AnonymousEqualityComparer(Func<T, T, bool> equals, Func<T, int> getHashCode)
+        {
+            this.equals = equals;
+            this.getHashCode = getHashCode;
+        }
+
+        public int GetHashCode(T obj)
+        {
+            return this.getHashCode(obj);
+        }
+
+        public bool Equals(T x, T y)
+        {
+            return this.equals(x, y);
+        }
+    }
+}

--- a/TinyNvidiaUpdateChecker/Extensions/LinqExtensions.cs
+++ b/TinyNvidiaUpdateChecker/Extensions/LinqExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TinyNvidiaUpdateChecker.Extensions
+{
+    public static class LinqExtensions
+    {
+        /// <summary>
+        ///     Returns distinct elements from a sequence using the specified equality and hash functions.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source" /></typeparam>
+        /// <param name="source">The sequence to remove duplicate elements from</param>
+        /// <param name="equals">A <see cref="Func{T1,T2,TResult}" /> to compare values</param>
+        /// <param name="getHashCode">A <see cref="Func{T1,TResult}" /> calculate the hash code of values</param>
+        /// <returns>An <see cref="IEnumerable{T}" /> that contains distinct elements from the source sequence</returns>
+        public static IEnumerable<TSource> Distinct<TSource>(this IEnumerable<TSource> source, Func<TSource, TSource, bool> equals, Func<TSource, int> getHashCode)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+            if (equals == null)
+                throw new ArgumentNullException(nameof(equals));
+            if (getHashCode == null)
+                throw new ArgumentNullException(nameof(getHashCode));
+
+            return source.Distinct(new AnonymousEqualityComparer<TSource>(equals, getHashCode));
+        }
+
+        /// <summary>
+        ///     Returns distinct elements from a sequence using the specified equality and hash functions.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source" /></typeparam>
+        /// <param name="source">The sequence to remove duplicate elements from</param>
+        /// <param name="equals">A <see cref="Func{T1,T2,TResult}" /> to compare values</param>
+        /// <param name="getHashCode">A <see cref="Func{T1,TResult}" /> calculate the hash code of values</param>
+        /// <returns>An <see cref="IEnumerable{T}" /> that contains distinct elements from the source sequence</returns>
+        public static IEnumerable<TSource> Distinct<TSource>(this IEnumerable source, Func<TSource, TSource, bool> equals, Func<TSource, int> getHashCode)
+        {
+            return Distinct(source?.Cast<TSource>(), equals, getHashCode);
+        }
+    }
+}

--- a/TinyNvidiaUpdateChecker/TinyNvidiaUpdateChecker.csproj
+++ b/TinyNvidiaUpdateChecker/TinyNvidiaUpdateChecker.csproj
@@ -72,19 +72,20 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AnonymousEqualityComparer.cs" />
     <Compile Include="DriverDialog.cs">
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="DriverDialog.Designer.cs">
       <DependentUpon>DriverDialog.cs</DependentUpon>
     </Compile>
+    <Compile Include="Extensions\LinqExtensions.cs" />
     <Compile Include="Handlers\FolderSelectDialog.cs" />
     <Compile Include="Handlers\GenericHandler.cs" />
     <Compile Include="Handlers\HashHandler.cs" />


### PR DESCRIPTION
I've added an additional command line argument to let the users choose which driver components they want to install. In my use case, for example, I always want to install/reinstall PhysX, so I can now launch TinyNvidiaUpdateChecker like this: `TinyNvidiaUpdateChecker.exe --quiet --install-components=PhysX`.

Multiple components should be separated by a comma: `--install-components=PhysX,HDAudio`.