### PR TITLE
Delete driver archive after extraction

### DIFF
--- a/TinyNvidiaUpdateChecker/MainConsole.cs
+++ b/TinyNvidiaUpdateChecker/MainConsole.cs
@@ -1118,12 +1118,12 @@ namespace TinyNvidiaUpdateChecker
                 Console.Write("OK!");
                 Console.WriteLine();
 
-                fullDriverPath = savePath + driverFileName;
                 try {
-                    File.Delete(fullDriverPath);
-                    Console.WriteLine("Cleaned up: " + fullDriverPath);
+                    File.Delete(savePath + driverFileName);
+                    File.Delete(savePath + "inclList.txt");
+                    Console.WriteLine("Cleaned up: driver archive and inclList.txt");
                 } catch {
-                    Console.WriteLine("Could not cleanup: " + fullDriverPath);
+                    Console.WriteLine("Could not cleanup: driver archive or inclList.txt");
                 }
             }
         }

--- a/TinyNvidiaUpdateChecker/MainConsole.cs
+++ b/TinyNvidiaUpdateChecker/MainConsole.cs
@@ -1117,6 +1117,14 @@ namespace TinyNvidiaUpdateChecker
             if (!error) {
                 Console.Write("OK!");
                 Console.WriteLine();
+
+                fullDriverPath = savePath + driverFileName;
+                try {
+                    File.Delete(fullDriverPath);
+                    Console.WriteLine("Cleaned up: " + fullDriverPath);
+                } catch {
+                    Console.WriteLine("Could not cleanup: " + fullDriverPath);
+                }
             }
         }
 


### PR DESCRIPTION
When the user has set `Minimal install` to `true` and selects "Download (+ Extract)": the archive is no longer needed after a successful extraction and can thus be deleted.

In the case where the user selects "Download + Install":
- if `Minimal install` is set to `true`, the archive will be removed before the installer is run, and `DownloadDriverQuiet()` will clean up the extracted installer separately in the end.
- if `Minimal install` is set to `false`, `MakeInstaller()` won't be called, so this commit has no effect.