### PR TITLE
Remove replacing "Super" with "SUPER" in GPU name

### DIFF
--- a/TinyNvidiaUpdateChecker/MainConsole.cs
+++ b/TinyNvidiaUpdateChecker/MainConsole.cs
@@ -372,7 +372,7 @@ namespace TinyNvidiaUpdateChecker
                 var name = gpu["Name"].ToString();
 
                 if (Regex.IsMatch(name, @"^NVIDIA") && regex.IsMatch(name)) {
-                    gpuName = regex.Match(name).Value.Trim().Replace("Super", "SUPER");
+                    gpuName = regex.Match(name).Value.Trim();
                     var rawDriverVersion = gpu["DriverVersion"].ToString().Replace(".", string.Empty);
                     OfflineGPUVersion = rawDriverVersion.Substring(rawDriverVersion.Length - 5, 5).Insert(3, ".");
                     foundCompatibleGpu = true;


### PR DESCRIPTION
I removed `.Replace("Super", "SUPER")`; it's no longer needed, as per https://github.com/ZenitH-AT/nvidia-data/commit/634caf6ea4642fa829d26b27662201d8e10638d6.

GPU names at [nvidia-data](https://github.com/ZenitH-AT/nvidia-data) should always match the names reported by the OS (without the "NVIDIA " prefix, " with Max-Q Design" suffix, etc.), so I added code to my script to replace "SUPER" with "Super".

For now, for the current version of TinyNvidiaUpdateChecker to stay compatible, nvidia-data's gpu-data.json includes duplicate key/value pairs with both "SUPER" and "Super" in the GPU name but if/after there's a new release implementing this PR, I will remove the "SUPER" ones.