### PR TITLE
Windows 11 OS identification fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Windows 11 systems identifying as Windows 10 (author: [jesseclvrt](https://github.com/jesseclvrt))
+
 ## [1.16.5] - 2023-05-13
 ### Fixed
 - Invalid minimal install extract libary paths could cause a `ArgumentNullException`. See issue #168

--- a/TinyNvidiaUpdateChecker/MainConsole.cs
+++ b/TinyNvidiaUpdateChecker/MainConsole.cs
@@ -508,10 +508,19 @@ namespace TinyNvidiaUpdateChecker
                 Environment.Exit(1);
             }
 
-            foreach (var os in osData) {
-                if (os.code == osVersion && Regex.IsMatch(os.name, osBit)) {
-                    osId = os.id;
-                    break;
+            if (osVersion == "10.0" && Environment.OSVersion.Version.Build >= 22000) {
+                foreach (var os in osData) {
+                    if (Regex.IsMatch(os.name, "Windows 11")) {
+                        osId = os.id;
+                        break;
+                    }
+                }
+            } else {
+                foreach (var os in osData) {
+                    if (os.code == osVersion && Regex.IsMatch(os.name, osBit)) {
+                        osId = os.id;
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
version number and architecture cannot be relied upon to differentiate windows 10 and 11. adds a check for build number to identify Windows 11 correctly.