### PR TITLE
Add --dry-run parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- `--dry-run` command line argumen (author: [TomKranenburg](https://github.com/TomKranenburg))
 ### Fixed
 - Internet connection failing whilst downloading driver is now properly communicated, see issue #204
 ### Changed

--- a/TinyNvidiaUpdateChecker/MainConsole.cs
+++ b/TinyNvidiaUpdateChecker/MainConsole.cs
@@ -85,6 +85,11 @@ namespace TinyNvidiaUpdateChecker
         /// </summary>
 	public static bool noPrompt = false;
 
+	/// <summary>
+        /// Just check for update. Don't install or download.
+        /// </summary>
+	public static bool justCheck = false;    
+
         /// <summary>
         /// Enable extended information
         /// </summary>
@@ -236,7 +241,7 @@ namespace TinyNvidiaUpdateChecker
                 updateAvailable = true;
             }
 
-            if (updateAvailable || forceDL) {
+            if ((updateAvailable || forceDL) && !justCheck) {
                 if (confirmDL) {
                     DownloadDriverQuiet(true);
                 } else {
@@ -277,7 +282,7 @@ namespace TinyNvidiaUpdateChecker
             if (new Version(onlineVer).CompareTo(new Version(offlineVer)) > 0) {
                 Console.WriteLine("There is a update available for TinyNvidiaUpdateChecker!");
 
-                if(!confirmDL) {
+                if(!confirmDL && !justCheck) {
                     DialogResult dialog = MessageBox.Show("There is a new client update available to download, do you want to be navigate to the official GitHub download section?", "TinyNvidiaUpdateChecker", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
 
                     if (dialog == DialogResult.Yes) {
@@ -314,6 +319,10 @@ namespace TinyNvidiaUpdateChecker
 				
 		else if (arg.ToLower() == "--noprompt") {
                     noPrompt = true;
+                }
+
+		else if (arg.ToLower() == "--justcheck") {
+                    justCheck = true;
                 }
 
                 // erase config
@@ -369,6 +378,7 @@ namespace TinyNvidiaUpdateChecker
                     Console.WriteLine();
                     Console.WriteLine("--quiet                      Runs the application quietly in the background, and will only notify the user if an update is available.");
                     Console.WriteLine("--noprompt                   Runs the application without prompting to exit.");
+                    Console.WriteLine("--justcheck                  Just check to see if new updates are available. Don't download and update.");
                     Console.WriteLine("--erase-config               Erase configuration file.");
                     Console.WriteLine("--debug                      Turn debugging on, will output more information that can be used for debugging.");
                     Console.WriteLine("--force-dl                   Force prompt to download drivers, even if the user is up-to-date - should only be used for debugging.");

--- a/TinyNvidiaUpdateChecker/MainConsole.cs
+++ b/TinyNvidiaUpdateChecker/MainConsole.cs
@@ -85,10 +85,10 @@ namespace TinyNvidiaUpdateChecker
         /// </summary>
         public static bool noPrompt = false;
 
-	/// <summary>
-        /// Just check for update. Don't install or download.
+	    /// <summary>
+        /// Dry run
         /// </summary>
-	public static bool justCheck = false;    
+	    public static bool dryRun = false;    
 
         /// <summary>
         /// Enable extended information
@@ -246,7 +246,7 @@ namespace TinyNvidiaUpdateChecker
                 updateAvailable = true;
             }
 
-            if ((updateAvailable || forceDL) && !justCheck) {
+            if ((updateAvailable || forceDL) && !dryRun) {
                 if (confirmDL) {
                     DownloadDriverQuiet(true);
                 } else {
@@ -287,7 +287,7 @@ namespace TinyNvidiaUpdateChecker
             if (new Version(onlineVer).CompareTo(new Version(offlineVer)) > 0) {
                 Console.WriteLine("There is a update available for TinyNvidiaUpdateChecker!");
 
-                if(!confirmDL && !justCheck) {
+                if(!confirmDL && !dryRun) {
                     DialogResult dialog = MessageBox.Show("There is a new client update available to download, do you want to be navigate to the official GitHub download section?", "TinyNvidiaUpdateChecker", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
 
                     if (dialog == DialogResult.Yes) {
@@ -326,8 +326,8 @@ namespace TinyNvidiaUpdateChecker
                     noPrompt = true;
                 }
 
-		else if (arg.ToLower() == "--dry-run") {
-                    justCheck = true;
+		        else if (arg.ToLower() == "--dry-run") {
+                    dryRun = true;
                 }
 
                 // erase config
@@ -383,7 +383,7 @@ namespace TinyNvidiaUpdateChecker
                     Console.WriteLine();
                     Console.WriteLine("--quiet                      Runs the application quietly in the background, and will only notify the user if an update is available.");
                     Console.WriteLine("--noprompt                   Runs the application without prompting to exit.");
-                    Console.WriteLine("--dry-run                  Just check to see if new updates are available. Don't download and update.");
+                    Console.WriteLine("--dry-run                    Perform a dry run.");
                     Console.WriteLine("--erase-config               Erase configuration file.");
                     Console.WriteLine("--debug                      Turn debugging on, will output more information that can be used for debugging.");
                     Console.WriteLine("--force-dl                   Force prompt to download drivers, even if the user is up-to-date - should only be used for debugging.");

--- a/TinyNvidiaUpdateChecker/MainConsole.cs
+++ b/TinyNvidiaUpdateChecker/MainConsole.cs
@@ -326,7 +326,7 @@ namespace TinyNvidiaUpdateChecker
                     noPrompt = true;
                 }
 
-		else if (arg.ToLower() == "--justcheck") {
+		else if (arg.ToLower() == "--dry-run") {
                     justCheck = true;
                 }
 
@@ -383,7 +383,7 @@ namespace TinyNvidiaUpdateChecker
                     Console.WriteLine();
                     Console.WriteLine("--quiet                      Runs the application quietly in the background, and will only notify the user if an update is available.");
                     Console.WriteLine("--noprompt                   Runs the application without prompting to exit.");
-                    Console.WriteLine("--justcheck                  Just check to see if new updates are available. Don't download and update.");
+                    Console.WriteLine("--dry-run                  Just check to see if new updates are available. Don't download and update.");
                     Console.WriteLine("--erase-config               Erase configuration file.");
                     Console.WriteLine("--debug                      Turn debugging on, will output more information that can be used for debugging.");
                     Console.WriteLine("--force-dl                   Force prompt to download drivers, even if the user is up-to-date - should only be used for debugging.");


### PR DESCRIPTION
Bothering you again so soon @ElPumpo (:

Let me know how you feel about this one. I have a better idea of your workflow now so this one should be a little easier. Hopefully.

I'm adding the --justcheck parameter that just checks for updates to both the app and the system GPU drivers. No download or installation is carried out. 

This allows the application to fit nicely into larger ecosystems.