### PR TITLE
Fix download integrity, socket leak, and driver extraction crash (#276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Edge case crash where driver download would ignore server errors. (Author: @Kkthnx)
+- Edge case crash if minimall install doesn't properly extract drivers, would cause crash. (Author: @Kkthnx)
+
 ## [1.25.0] - 2026-06-18
 ### Added
 - Disable installer telemetry and installer ads

--- a/TinyNvidiaUpdateChecker/Handlers/ComponentHandler.cs
+++ b/TinyNvidiaUpdateChecker/Handlers/ComponentHandler.cs
@@ -11,6 +11,12 @@ namespace TinyNvidiaUpdateChecker.Handlers
             List<Component> components = [];
             XmlDocument doc = new();
 
+            // Return empty list if directory is not found
+            if (!Directory.Exists(driverRootPath))
+            {
+                return components;
+            }
+
             foreach (string dir in Directory.GetDirectories(driverRootPath))
             {
                 string nviFile = FindNviFile(dir);

--- a/TinyNvidiaUpdateChecker/Handlers/HttpClientProgressExtensions.cs
+++ b/TinyNvidiaUpdateChecker/Handlers/HttpClientProgressExtensions.cs
@@ -12,6 +12,9 @@ namespace HttpClientProgress
         {
             using (var response = await client.GetAsync(requestUrl, HttpCompletionOption.ResponseHeadersRead))
             {
+                // Validate success status
+                response.EnsureSuccessStatusCode();
+
                 var contentLength = response.Content.Headers.ContentLength;
                 using (var download = await response.Content.ReadAsStreamAsync())
                 {

--- a/TinyNvidiaUpdateChecker/MainConsole.cs
+++ b/TinyNvidiaUpdateChecker/MainConsole.cs
@@ -306,12 +306,14 @@ namespace TinyNvidiaUpdateChecker
             }
 
             var updateAvailable = false;
-            var iOffline = int.Parse(OfflineGPUVersion.Replace(".", string.Empty));
-            var iOnline = int.Parse(OnlineGPUVersion.Replace(".", string.Empty));
 
-            if (iOnline == iOffline) {
+            Version.TryParse(OfflineGPUVersion, out Version vOffline);
+            Version.TryParse(OnlineGPUVersion, out Version vOnline);
+            int comparison = vOffline.CompareTo(vOnline);
+
+            if (comparison == 0) {
                 WriteLine("There is no new GPU driver available, you are up to date.");
-            } else if (iOffline > iOnline) {
+            } else if (comparison > 0) {
                 WriteLine("Your current GPU driver is newer than what NVIDIA reports!");
             } else {
                 WriteLine("There is a new GPU driver available to download!");
@@ -803,7 +805,6 @@ namespace TinyNvidiaUpdateChecker
                 File.Delete(path);
             }
 
-            HttpClient client = new();
             Progress<float> progress = new();
             Handlers.ProgressBar progressBar = null;
 
@@ -819,7 +820,7 @@ namespace TinyNvidiaUpdateChecker
 
             try {
                 using (FileStream file = new(path, FileMode.Create, FileAccess.Write, FileShare.None))  {
-                    await client.DownloadDataAsync(url, file, progress);
+                    await httpClient.DownloadDataAsync(url, file, progress);
                 }
 
                 File.Move(path, path[..^5]); // rename back
@@ -905,8 +906,23 @@ namespace TinyNvidiaUpdateChecker
                 callExit(1);
             }
 
+            string extractedPath = $"{savePath}temp";
+
+            // If extraction was successful (code 0), but extract directory was not found
+            if (!Directory.Exists(extractedPath)) {
+                Write("ERROR!");
+                WriteLine();
+                WriteLine("The driver archive extracted without error but no files were found. Please rerun TNUC, and disable the Minimal Install feature if the issue doesn't go away.");
+                WriteLine();
+                WriteLine("Minimal Install info:");
+                WriteLine($"Library: {library}");
+                WriteLine($"Installation Directory: {libraryFile.GetInstallationDirectory()}");
+                WriteLine($"Expected extract path: {extractedPath}");
+                callExit(1);
+            }
+
             // Analyze with ComponentHandler
-            List<Handlers.Component> components = ComponentHandler.ParseComponentData($"{savePath}temp");
+            List<Handlers.Component> components = ComponentHandler.ParseComponentData(extractedPath);
             
             string textComponents = ConfigurationHandler.ReadSetting("Minimal install components", components, true);
             string[] arrayComponents = textComponents


### PR DESCRIPTION
Three download/extraction fixes.

- Downloads never checked the HTTP status, so a failed request (404/403/expired CDN link) wrote the error page body into the file, producing a corrupt driver or self-update. Now calls EnsureSuccessStatusCode() before reading the stream.
- HandleDownload created a new HttpClient on every download and never disposed it. Now reuses the shared client.
- ParseComponentData crashed with DirectoryNotFoundException when the extractor exited 0 but produced no temp folder (Issue #276). Added a guard in MakeInstaller with a clear message, and ParseComponentData returns empty instead of throwing.
- Version comparison uses Version.TryParse instead of concatenating the version digits.

Changelog updated.