### PR TITLE
Fix edge cases where self-updater would fail and crash. It now properly restores the old version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Fixed
-- Self-update crash when the running executable could not be replaced
-- Self-update failing silently instead of showing the error
+- Edge cases where self-updater would fail and crash. It now properly restores the old version. (Author: @Kkthnx)
 
 ## [1.25.0] - 2026-06-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Self-update crash when the running executable could not be replaced
+- Self-update failing silently instead of showing the error
+
 ## [1.25.0] - 2026-06-18
 ### Added
 - Disable installer telemetry and installer ads

--- a/TinyNvidiaUpdateChecker/Handlers/UpdateHandler.cs
+++ b/TinyNvidiaUpdateChecker/Handlers/UpdateHandler.cs
@@ -61,10 +61,13 @@ namespace TinyNvidiaUpdateChecker.Handlers
         private static void UpdateNow(string[] args, string downloadUrl, string serverHash)
         {
             string currentExe = Path.GetFullPath(Environment.ProcessPath);
+            string backupExe = currentExe + ".old";
+            string tempFile = Path.Combine(Path.GetTempPath(), "TinyNvidiaUpdateChecker.tmp");
+            bool movedToBackup = false;
 
             try {
-                string tempFile = Path.Combine(Path.GetTempPath(), "TinyNvidiaUpdateChecker.tmp");
-                File.Move(currentExe, currentExe + ".old", true);
+                File.Move(currentExe, backupExe, true);
+                movedToBackup = true;
 
                 Console.WriteLine();
                 Console.Write("Downloading update . . . ");
@@ -87,18 +90,31 @@ namespace TinyNvidiaUpdateChecker.Handlers
                     string runArgs = string.Join(" ", args) + " --cleanup-update";
                     Process.Start(new ProcessStartInfo(currentExe) { UseShellExecute = true, Arguments = runArgs });
                     Environment.Exit(0);
-                } else {
-                    Console.WriteLine("ERROR!");
-                    Console.WriteLine("Checksum mismatch!");
-                    Console.WriteLine();
-                    Console.WriteLine($"Calculated Hash: {tempHash}");
-                    Console.WriteLine($"Server Hash:     {serverHash}");
                 }
-            } catch { }
+
+                Console.WriteLine("ERROR!");
+                Console.WriteLine("Checksum mismatch!");
+                Console.WriteLine();
+                Console.WriteLine($"Calculated Hash: {tempHash}");
+                Console.WriteLine($"Server Hash:     {serverHash}");
+            } catch (Exception ex) {
+                Console.WriteLine("ERROR!");
+                Console.WriteLine();
+                Console.WriteLine(ex.ToString());
+            } finally {
+                // Remove temp file if not deleted by updater
+                if (File.Exists(tempFile)) {
+                    try { File.Delete(tempFile); } catch { }
+                }
+
+                // If updater failed (currentExe is missing) and backupExe still exists, try to restore it
+                if (movedToBackup && !File.Exists(currentExe) && File.Exists(backupExe)) {
+                    try { File.Move(backupExe, currentExe, true); } catch { }
+                }
+            }
 
             Console.WriteLine("Update failed, please update manually.");
             Console.WriteLine();
-            File.Move(currentExe + ".old", currentExe, true);
         }
 
         public static string CalculateSHA256(string filePath)


### PR DESCRIPTION
UpdateNow had a few problems in its failure handling:

- An empty catch {} hid every error, so the user only ever saw "Update failed, please update manually." with no reason.
- If the initial move of the running exe to .old failed, the swallowed exception fell through to the restore File.Move(.old -> exe), which then threw because the .old backup never existed - turning a recoverable failure into a crash.
- The downloaded temp file leaked whenever the update did not complete (e.g. checksum mismatch).

Reworked with a finally block that prints the actual error, deletes the temp file if it was not used, and restores the backup only if we actually moved it aside and it still exists. Success path is unchanged.

Changelog updated.